### PR TITLE
Ensure `launched` is false when a background notification is received

### DIFF
--- a/lib/ProMotion/delegate_notifications.rb
+++ b/lib/ProMotion/delegate_notifications.rb
@@ -94,7 +94,7 @@ module ProMotion
     end
 
     def application(application, didReceiveRemoteNotification: notification, fetchCompletionHandler: callback)
-      result = received_push_notification(notification, application.applicationState != UIApplicationStateActive)
+      result = received_push_notification(notification, application.applicationState == UIApplicationStateInactive)
       callback.call(background_fetch_result(result))
     end
 


### PR DESCRIPTION
Currently the `on_push_notification` method sets `launched` to true if the user has received a background push notification.

1. When the push arrives with the app in the background, the state is `UIApplicationStateBackground`
2. If you open it from a push notification, the state is `UIApplicationStateInactive`
3. If it arrives while the app is in the foreground, the state is `UIApplicationStateActive`

Therefore we only want launched to be true for `UIApplicationStateInactive`.